### PR TITLE
Modultestevents

### DIFF
--- a/addons-loaded/website_event_register_free
+++ b/addons-loaded/website_event_register_free
@@ -1,0 +1,1 @@
+../addons-thirdparty/website/website_event_register_free

--- a/addons-loaded/website_event_register_free_with_sale
+++ b/addons-loaded/website_event_register_free_with_sale
@@ -1,0 +1,1 @@
+../addons-thirdparty/website/website_event_register_free_with_sale

--- a/addons-own/base_config/models/res_config.py
+++ b/addons-own/base_config/models/res_config.py
@@ -88,7 +88,7 @@ class base_config_settings(osv.osv_memory):
         'module_mail_outgoing': fields.boolean('mail_outgoing -- Outgoing E-Mail overview for admins'),
         'module_mail_fix_553': fields.boolean('mail_fix_553 -- change Domain of FROM field for outgoing mails'),
         'module_inactive_session_timeout': fields.boolean('inactive_session_timeout -- Remove all inactive session after a given time'),
-        'website_event_register_free': fields.boolean('website_event_register_free -- prevents sales order and shop payment on cost free event tickets'),
+        'module_website_event_register_free': fields.boolean('website_event_register_free -- prevents sales order and shop payment on cost free event tickets'),
 
         # Addons Own
         'module_website_crm_extended': fields.boolean('website_crm_extended -- Default sales group for lead from contact formular',

--- a/addons-own/base_config/models/res_config.py
+++ b/addons-own/base_config/models/res_config.py
@@ -88,6 +88,7 @@ class base_config_settings(osv.osv_memory):
         'module_mail_outgoing': fields.boolean('mail_outgoing -- Outgoing E-Mail overview for admins'),
         'module_mail_fix_553': fields.boolean('mail_fix_553 -- change Domain of FROM field for outgoing mails'),
         'module_inactive_session_timeout': fields.boolean('inactive_session_timeout -- Remove all inactive session after a given time'),
+        'website_event_register_free': fields.boolean('website_event_register_free -- prevents sales order and shop payment on cost free event tickets'),
 
         # Addons Own
         'module_website_crm_extended': fields.boolean('website_crm_extended -- Default sales group for lead from contact formular',

--- a/addons-own/base_config/views/res_config.xml
+++ b/addons-own/base_config/views/res_config.xml
@@ -130,6 +130,10 @@
                                     <field name="module_inactive_session_timeout" class="oe_inline" />
                                     <label for="module_inactive_session_timeout" />
                                 </div>
+                                <div>
+                                    <field name="website_event_register_free" class="oe_inline" />
+                                    <label for="website_event_register_free" />
+                                </div>
 							</div>
 						</div>
 					</group>

--- a/addons-own/base_config/views/res_config.xml
+++ b/addons-own/base_config/views/res_config.xml
@@ -131,8 +131,8 @@
                                     <label for="module_inactive_session_timeout" />
                                 </div>
                                 <div>
-                                    <field name="website_event_register_free" class="oe_inline" />
-                                    <label for="website_event_register_free" />
+                                    <field name="module_website_event_register_free" class="oe_inline" />
+                                    <label for="module_website_event_register_free" />
                                 </div>
 							</div>
 						</div>


### PR DESCRIPTION
Mdule hinzugefügt und getestet 
mögliche Abhängigkeiten zu bestehenden Shop Modulen sind noch zu überlegen 
ansonsten sollten die beiden Module soweit getestet sein 
INSTALL --> OK 
website_event_free --> OK installiert automatisch
website_event_free_with_sale --> OK dazu 
TESTS:
veranstaltung kostenlos --> OK 
check --> keine sales order --> OK 
kein weiterführende Paymentmethodenauswahl abschlusss mit danke für die registrierung --> OK
veranstalung kostenpflichtig --> OK 
check --> sales order wie bei einem normalen Produkt --> OK 
Checkout normales Spendenprodukt --> OK 